### PR TITLE
Add local PDF text extraction script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Notion Timer
+
+This repository now includes a small script for extracting text from a PDF file using [PyMuPDF](https://pypi.org/project/PyMuPDF/).
+
+## Requirements
+
+- Python 3.9+
+- `pymupdf`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the script with a path to your PDF file. The extracted text will be saved to `extracted_text.txt` by default.
+
+```bash
+python extract_text.py myfile.pdf
+```
+
+You can specify a custom output file with `-o`:
+
+```bash
+python extract_text.py myfile.pdf -o output.txt
+```
+
+The extraction runs entirely locally and does not upload any data.

--- a/extract_text.py
+++ b/extract_text.py
@@ -1,0 +1,22 @@
+import fitz
+
+def extract_text_from_pdf(file_path):
+    text = ""
+    with fitz.open(file_path) as pdf_document:
+        for page_num in range(len(pdf_document)):
+            page = pdf_document.load_page(page_num)
+            text += page.get_text()
+    return text
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Extract text from a PDF file")
+    parser.add_argument("pdf", help="Path to the PDF file")
+    parser.add_argument("-o", "--output", default="extracted_text.txt",
+                        help="Output text file")
+    args = parser.parse_args()
+
+    extracted = extract_text_from_pdf(args.pdf)
+    with open(args.output, "w", encoding="utf-8") as text_file:
+        text_file.write(extracted)
+    print(f"Text extracted successfully to '{args.output}'")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pymupdf


### PR DESCRIPTION
## Summary
- add `extract_text.py` for extracting text from PDFs with PyMuPDF
- document usage in `README.md`
- declare dependency in `requirements.txt`

## Testing
- `pip install pymupdf`
- Created a small sample PDF and successfully extracted text using the new script

------
https://chatgpt.com/codex/tasks/task_e_683ff730386c832e9c38e9550c41c912